### PR TITLE
Fix index property (package.json)

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "package-config-checker",
   "version": "1.0.0",
   "description": "Checks if your dependencies have package.json files config or an .npmignore for packaging",
-  "main": "index.js",
+  "main": "bin/package-config-checker.js",
   "bin": {
     "package-config-checker": "bin/package-config-checker.js"
   },


### PR DESCRIPTION
### Before

```
❯ package-config-checker at master ✔ node . --help
module.js:442
    throw err;
    ^

Error: Cannot find module '/Users/matheus/dev/forks/package-config-checker'
[...]
```
### After

```
❯ package-config-checker at fix-index-prop ✔ node . --help
Usage: package-config-checker
[...]
```
